### PR TITLE
chore(CI): remove nodejs v10. Tailwind does not support the version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         node: 
-          - '10.x'
           - '12.x'
           - '14.x'
         os: 


### PR DESCRIPTION
Tailwind does not support the version.
So we have to remove it from CI.


https://github.com/digitalcube/galaxy/pull/18/checks?check_run_id=2012098169`
```
error tailwindcss@2.0.3: The engine "node" is incompatible with this module. Expected version ">=12.13.0". Got "10.23.3"`
```